### PR TITLE
Test: Remove unused import and reorder imports

### DIFF
--- a/dino.py
+++ b/dino.py
@@ -1,6 +1,7 @@
-import pyautogui
-from PIL import Image, ImageGrab
 import time
+
+import pyautogui
+from PIL import ImageGrab
 
 def hit(key):
     pyautogui.keyDown(key)


### PR DESCRIPTION
## Summary
Minor cleanup: removes the unused `Image` import from PIL and reorders imports to follow PEP 8 convention (stdlib first, then third-party). Also adds a missing newline at end of file.

## Review & Testing Checklist for Human
- [ ] Confirm `Image` is not used anywhere in `dino.py` (it isn't in the current code, but verify no indirect usage)

### Notes
- [Link to Devin run](https://staging.itsdev.in/sessions/8e70e9719fe2434998bff894e1082841)
- Requested by: @Aman-Verma-28
<!-- devin-review-badge-staging-begin -->

---

<a href="https://staging.itsdev.in/review/aman-verma-28/autodino/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Staging: Open in Devin">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
